### PR TITLE
Use docker name instead of docker id for cleaning up containers.

### DIFF
--- a/agent/engine/docker_task_engine.go
+++ b/agent/engine/docker_task_engine.go
@@ -531,7 +531,7 @@ func (engine *DockerTaskEngine) removeContainer(task *api.Task, container *api.C
 		return errors.New("No container named '" + container.Name + "' created in " + task.Arn)
 	}
 
-	return engine.client.RemoveContainer(dockerContainer.DockerId)
+	return engine.client.RemoveContainer(dockerContainer.DockerName)
 }
 
 // updateTask determines if a new transition needs to be applied to the


### PR DESCRIPTION
Pulled from aws:dev, as discussed in AWS case 1719643441.

Reminder: this is now a public repo.
